### PR TITLE
Compatibility with OCaml 4.03.0 and later

### DIFF
--- a/src/modelica_lexer.ml
+++ b/src/modelica_lexer.ml
@@ -137,8 +137,8 @@ let letter = [%sedlex.regexp? 'a'..'z'|'A'..'Z']
 
 let white_space = [%sedlex.regexp? 
                                    0x09 | 0x0b | 0x0c | 0x20 | 0x85 | 0xa0 | 0x1680 |
-                                 0x2000 .. 0x200a | 0x2028 .. 0x2029 | 0x202f.. 0x202f | 0x205f.. 0x205f |
-                                 0x3000.. 0x3000 | 0xfeff]
+                                 0x2000 .. 0x200a | 0x2028 .. 0x2029 | 0x202f .. 0x202f | 0x205f .. 0x205f |
+                                 0x3000 .. 0x3000 | 0xfeff]
 
 let state_from_utf8_string src input = {
   buf = Utf8.from_string input ;


### PR DESCRIPTION
OCaml 4.03.0 introduced hexadecimal floating-point constants, which changed the syntax slightly. You now need the space between your hex constant and the following `..` operator.